### PR TITLE
Update Dockerfile.hpu with base image on 1.20.0

### DIFF
--- a/Dockerfile.hpu
+++ b/Dockerfile.hpu
@@ -1,4 +1,4 @@
-FROM vault.habana.ai/gaudi-docker/1.19.1/ubuntu22.04/habanalabs/pytorch-installer-2.5.1:latest
+FROM vault.habana.ai/gaudi-docker/1.20.0/ubuntu24.04/habanalabs/pytorch-installer-2.6.0:latest
 
 COPY ./ /workspace/vllm
 


### PR DESCRIPTION

FIX customer issue:

build vLLM-fork, not with 1.19, but with 1.20
